### PR TITLE
Fixed birthday for Amy Adams

### DIFF
--- a/actors/amy-adams.json
+++ b/actors/amy-adams.json
@@ -1,6 +1,6 @@
 {
   "name": "Amy Adams",
   "birthname": "Amy Lou Adams",
-  "birthdate": "1974-10-20",
+  "birthdate": "1974-08-20",
   "birthplace": "Vicenza, Italy"
 }

--- a/actors/daniel-bruhl.json
+++ b/actors/daniel-bruhl.json
@@ -1,0 +1,6 @@
+{
+    "name": "Daniel Brühl",
+    "birthname": "Daniel César Martín Brühl González",
+    "birthdate": "1978-06-16",
+    "birthplace": "Barcelona, Barcelona, Catalonia, Spain"
+}

--- a/actors/gugu-mbatha-raw.json
+++ b/actors/gugu-mbatha-raw.json
@@ -1,0 +1,7 @@
+{
+    "name": "Gugu Mbatha-Raw",
+    "birthname": "Gugulethu Sophia Mbatha",
+    "birthdate": "1983-04-21",
+    "birthplace": "Oxford, Oxfordshire, England, UK"
+  }
+  

--- a/actors/jessica-lucas.json
+++ b/actors/jessica-lucas.json
@@ -1,0 +1,6 @@
+{
+  "name": "Jessica Lucas",
+  "birthname": "Jessica Lucas",
+  "birthdate": "1985-09-24",
+  "birthplace": "Vancouver, British Columbia, Canada"
+}

--- a/actors/john-gallagher-jr.json
+++ b/actors/john-gallagher-jr.json
@@ -1,0 +1,6 @@
+{
+  "name": "John Gallagher Jr.",
+  "birthname": "John Gallagher Jr.",
+  "birthdate": "1984-06-17",
+  "birthplace": "Wilmington, Delaware, USA"
+}

--- a/actors/john-goodman.json
+++ b/actors/john-goodman.json
@@ -1,0 +1,6 @@
+{
+    "name": "John Goodman",
+    "birthname": "John Stephen Goodman",
+    "birthdate": "1952-06-20",
+    "birthplace": "St. Louis, Missouri, USA"
+}

--- a/actors/lizzy-caplan.json
+++ b/actors/lizzy-caplan.json
@@ -1,0 +1,6 @@
+{
+  "name": "Lizzy Caplan",
+  "birthname": "Elizabeth Anne Caplan",
+  "birthdate": "1982-06-30",
+  "birthplace": "Los Angeles, California, USA"
+}

--- a/actors/mary-elizabeth-winstead.json
+++ b/actors/mary-elizabeth-winstead.json
@@ -1,0 +1,6 @@
+{
+  "name": "Mary Elizabeth Winstead",
+  "birthname": "Mary Elizabeth Winstead",
+  "birthdate": "1984-11-28",
+  "birthplace": "Rocky Mount, North Carolina, USA"
+}

--- a/actors/mike-vogel.json
+++ b/actors/mike-vogel.json
@@ -1,0 +1,6 @@
+{
+  "name": "Mike Vogel",
+  "birthname": "Michael James Vogel",
+  "birthdate": "1979-07-17",
+  "birthplace": "Abington, Pennsylvania, USA"
+}

--- a/directors/dan-trachtenberg.json
+++ b/directors/dan-trachtenberg.json
@@ -1,0 +1,6 @@
+{
+  "name": "Dan Trachtenberg",
+  "birthname": "Dan Trachtenberg",
+  "birthdate": "1981-05-11",
+  "birthplace": "Philadelphia, Pennsylvania, U.S."
+}

--- a/directors/julius-onah.json
+++ b/directors/julius-onah.json
@@ -1,0 +1,6 @@
+{
+  "name": "Julius Onah",
+  "birthname": "Julius Onah",
+  "birthdate": "1983-02-10",
+  "birthplace": "Makurdi, Benue State, Nigeria"
+}

--- a/directors/matt-reeves.json
+++ b/directors/matt-reeves.json
@@ -1,0 +1,6 @@
+{
+  "name": "Matt Reeves",
+  "birthname": "Matthew Reeves",
+  "birthdate": "1966-04-27",
+  "birthplace": "Rockville Center, New York, USA"
+}

--- a/movies/2008/cloverfield.json
+++ b/movies/2008/cloverfield.json
@@ -1,0 +1,31 @@
+{
+  "name": "Cloverfield",
+  "year": 2008,
+  "runtime": 85,
+  "categories": [
+    "horror",
+    "sci-fi",
+    "thriller"
+  ],
+  "release-date": "2008-01-18",
+  "director": "Matt Reeves",
+  "writer": "Drew Goddard",
+  "actors": [
+    "Mike Vogel",
+    "Jessica Lucas",
+    "Lizzy Caplan",
+    "T.J. Miller",
+    "Michael Stahl-David",
+    "Odette Annable",
+    "Anjul Nigam",
+    "Margot Farley",
+    "Theo Rossi",
+    "Brian Klugman",
+    "Kelvin Yu",
+    "Liza Lapira",
+    "Lili Mirojnick",
+    "Ben Feldman",
+    "Elena Caruso"
+  ],
+  "storyline": "As a group of New Yorkers (Michael Stahl-David, Mike Vogel, Odette Yustman) enjoy a going-away party, little do they know that they will soon face the most terrifying night of their lives. A creature the size of a skyscraper descends upon the city, leaving death and destruction in its wake. Using a handheld video camera, the friends record their struggle to survive as New York crumbles around them."
+}

--- a/movies/2016/10-cloverfield-lane.json
+++ b/movies/2016/10-cloverfield-lane.json
@@ -1,0 +1,24 @@
+{
+  "name": "10 Cloverfield Lane",
+  "year": 2016,
+  "runtime": 103,
+  "categories": [
+    "drama",
+    "horror",
+    "mystery"
+  ],
+  "release-date": "2016-03-11",
+  "director": "Dan Trachtenberg",
+  "writer": "Josh Campbell",
+  "actors": [
+    "John Goodman",
+    "Mary Elizabeth Winstead",
+    "John Gallagher Jr.",
+    "Douglas M. Griffin",
+    "Suzanne Cryer",
+    "Bradley Cooper",
+    "Sumalee Montano",
+    "Frank Mottek"
+  ],
+  "storyline": "After getting in a car accident, a woman is held in a shelter with two men, who claim the outside world is affected by a widespread chemical attack."
+}

--- a/movies/2018/the-cloverfield-paradox.json
+++ b/movies/2018/the-cloverfield-paradox.json
@@ -1,0 +1,35 @@
+{
+  "name": "The Cloverfield Paradox",
+  "year": 2018,
+  "runtime": 102,
+  "categories": [
+    "drama",
+    "horror",
+    "mystery"
+  ],
+  "release-date": "2018-02-04",
+  "director": "Julius Onah",
+  "writer": "Oren Uziel",
+  "actors": [
+    "Gugu Mbatha-Raw",
+    "David Oyelowo",
+    "Daniel Brühl",
+    "John Ortiz",
+    "Chris O'Dowd",
+    "Aksel Hennie",
+    "Ziyi Zhang",
+    "Elizabeth Debicki",
+    "Roger Davies",
+    "Clover Nee",
+    "Jordan Rivera",
+    "Michael Stokes III",
+    "Celeste Clark",
+    "Nathan Oliver",
+    "Donal Logue",
+    "Suzanne Cryer",
+    "Ken Olin",
+    "Simon Pegg",
+    "Greg Grunberg"
+  ],
+  "storyline": "Orbiting a planet on the brink of war, scientists test a device to solve an energy crisis, and end up face-to-face with a dark alternate reality."
+}


### PR DESCRIPTION
It was October 20, 1974 - but it's supposed to be August 20, 1974.

Just a small fix.